### PR TITLE
Add function to process text to get POS tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 - Meet the data science cookiecutter [requirements](http://nestauk.github.io/ds-cookiecutter/quickstart), in brief:
   - Install: `direnv` and `conda`
+- Create a blank cookiecutter conda log file:
+  - `mkdir .cookiecutter/state`
+  - `touch .cookiecutter/state/conda-create.log`
 - Run `make install` to configure the development environment:
   - Setup the conda environment
   - Configure `pre-commit`

--- a/comp_sci_gender_bias/pipeline/process_text_utils.py
+++ b/comp_sci_gender_bias/pipeline/process_text_utils.py
@@ -20,17 +20,14 @@ class TextCleaner:
     def spell_check(self, word):
         """
         Spell check a word unless it is an abbreviation or acronym
+        and return first suggestion
         hunspell = Hunspell()
         """
-        if (len(word) <= 3) or word.isupper():
-            # Assumed abbreviation or acronym
-            return word
-        else:
-            # Spellcheck and return first suggestion
-            if self.hunspell.spell(word):
-                return word
-            else:
-                return self.hunspell.suggest(word)[0]
+        return (
+            word
+            if (len(word) <= 3) or word.isupper() or self.hunspell.spell(word)
+            else self.hunspell.suggest(word)[0]
+        )
 
     def clean(self, text):
         """

--- a/comp_sci_gender_bias/pipeline/process_text_utils.py
+++ b/comp_sci_gender_bias/pipeline/process_text_utils.py
@@ -1,4 +1,44 @@
 import spacy_udpipe
+from hunspell import Hunspell
+
+import re
+
+
+class TextCleaner:
+    def __init__(self, replace_char=" "):
+        self.hunspell = Hunspell()
+        self.replace_char = replace_char
+
+    def strip_nonalphanumeric(self, text):
+        """
+        Replace all nonalphanumeric characters in a text string
+        with replace_char
+        """
+
+        return re.sub("[^0-9a-zA-Z]+", self.replace_char, text)
+
+    def spell_check(self, word):
+        """
+        Spell check a word unless it is an abbreviation or acronym
+        hunspell = Hunspell()
+        """
+        if (len(word) <= 3) or word.isupper():
+            # Assumed abbreviation or acronym
+            return word
+        else:
+            # Spellcheck and return first suggestion
+            if self.hunspell.spell(word):
+                return word
+            else:
+                return self.hunspell.suggest(word)[0]
+
+    def clean(self, text):
+        """
+        Apply all the cleaning steps to a text string
+        """
+        text = self.strip_nonalphanumeric(text)
+
+        return " ".join([self.spell_check(word) for word in text.split()])
 
 
 class TokenTagger:

--- a/comp_sci_gender_bias/pipeline/process_text_utils.py
+++ b/comp_sci_gender_bias/pipeline/process_text_utils.py
@@ -1,0 +1,18 @@
+import spacy_udpipe
+
+
+class TokenTagger:
+    def __init__(self):
+
+        spacy_udpipe.download("en")
+        self.nlp = spacy_udpipe.load("en")
+
+    def tag(self, sentence):
+        """
+        Tokenise a single sentence and output a list of tuples
+        (text, lemma, POS) for each token
+        """
+
+        doc = self.nlp(sentence)
+
+        return [(token.text, token.lemma_, token.pos_) for token in doc]

--- a/comp_sci_gender_bias/pipeline/process_text_utils.py
+++ b/comp_sci_gender_bias/pipeline/process_text_utils.py
@@ -7,12 +7,19 @@ class TokenTagger:
         spacy_udpipe.download("en")
         self.nlp = spacy_udpipe.load("en")
 
-    def tag(self, sentence):
+    def tag(self, sentence, convert_propn=True):
         """
         Tokenise a single sentence and output a list of tuples
         (text, lemma, POS) for each token
+
+        If convert_propn==True then convert all proper nouns to nouns
         """
 
         doc = self.nlp(sentence)
 
-        return [(token.text, token.lemma_, token.pos_) for token in doc]
+        tags = [(token.text, token.lemma_, token.pos_) for token in doc]
+
+        if convert_propn:
+            return [(t, l, "NOUN") if p == "PROPN" else (t, l, p) for (t, l, p) in tags]
+        else:
+            return tags

--- a/comp_sci_gender_bias/tests/test_process_text.py
+++ b/comp_sci_gender_bias/tests/test_process_text.py
@@ -1,6 +1,6 @@
 import pytest
 
-from comp_sci_gender_bias.pipeline.process_text_utils import TokenTagger
+from comp_sci_gender_bias.pipeline.process_text_utils import TokenTagger, TextCleaner
 
 
 def test_TokenTagger():
@@ -14,3 +14,19 @@ def test_TokenTagger():
 
     tags = token_tagger.tag(sentence, convert_propn=False)
     assert tags[0][2] == "PROPN"
+
+
+def test_CleanText():
+
+    text_cleaner = TextCleaner()
+
+    cleaned_text = text_cleaner.clean("clean_me!!1")
+    assert cleaned_text == "clean me 1"
+
+    # Check "acronyms" aren't being corrected
+    cleaned_text = text_cleaner.clean("change thsi but not THSI")
+    assert cleaned_text == "change this but not THSI"
+
+    # Check short words aren't corrected
+    text = "a cta and dgo"
+    assert text_cleaner.clean(text) == text

--- a/comp_sci_gender_bias/tests/test_process_text.py
+++ b/comp_sci_gender_bias/tests/test_process_text.py
@@ -1,0 +1,11 @@
+import pytest
+
+from comp_sci_gender_bias.pipeline.process_text_utils import TokenTagger
+
+
+def test_TokenTagger():
+
+    token_tagger = TokenTagger()
+    tags = token_tagger.tag("This is a test")
+
+    assert len(tags) == 4

--- a/comp_sci_gender_bias/tests/test_process_text.py
+++ b/comp_sci_gender_bias/tests/test_process_text.py
@@ -6,6 +6,11 @@ from comp_sci_gender_bias.pipeline.process_text_utils import TokenTagger
 def test_TokenTagger():
 
     token_tagger = TokenTagger()
-    tags = token_tagger.tag("This is a test")
 
+    sentence = "London is in England"
+    tags = token_tagger.tag(sentence)
     assert len(tags) == 4
+    assert tags[0][2] == "NOUN"
+
+    tags = token_tagger.tag(sentence, convert_propn=False)
+    assert tags[0][2] == "PROPN"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ typer
 sh
 python-docx
 spacy-udpipe
+cyhunspell

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ filelock
 typer
 sh
 python-docx
+spacy-udpipe


### PR DESCRIPTION
Closes #6 

This PR:
- Adds a class to get POS/lemma/tokens for each word in a sentence.
- Adds a class to clean text (alphanumeric only, plus spellchecks)
- Adds a tests for these functions
- Adds an instruction to the README about creating a blank conda log (needed to get `make install` to work)

I created the `TokenTagger` as a class since it means we can load the model once.

As in BITs methodology we have an option to convert proper nouns to nouns. I keep this as an option (although default) as we might want to experiment with it in the future.

## Usage

```
from comp_sci_gender_bias.pipeline.process_text_utils import TextCleaner, TokenTagger
text_cleaner = TextCleaner()
token_tagger = TokenTagger()

text = "proccess this text for me!!"
cleaned_text = text_cleaner.clean(text)
tags = token_tagger.tag(cleaned_text)
tags
>>> [('process', 'process', 'NOUN'), ('this', 'this', 'DET'), ('text', 'text', 'NOUN'), ('for', 'for', 'ADP'), ('me', 'I', 'PRON')]
```


## Thoughts
- I'm not sure if this location is the best place for this new script? 
- `process_text_utils.py` could contain all the functions for text processing including the cleaning steps.
- We may want to use something other than `spacy_udpipe` for POS tagging?
- Perhaps the TextCleaner doesn't need to be a class, but it might make things neater if we add more cleaning steps at a later date
- We may need to check BITs code once we get it - but I assumed the spell check would need to be applied to the whole text before the POS tags are created, e.g. a more efficient thing to do would be `[(spell_check(token.text), token.lemma_, token.pos_) for token in doc]` but the outcome of the spell check will effect the lemma and pos predicted

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
